### PR TITLE
Create _init_.py

### DIFF
--- a/more_itertools/_init_
+++ b/more_itertools/_init_
@@ -1,0 +1,4 @@
+from .more import *  # noqa
+from .recipes import *  # noqa
+
+__version__ = '8.8.0'


### PR DESCRIPTION
commit alterado

## Summary by Sourcery

Chores:
- Add an empty `_init_.py` file to the `more_itertools` directory.