### PR TITLE
Create _init_.py

### DIFF
--- a/Cli/_init_.py
+++ b/Cli/_init_.py
@@ -1,0 +1,4 @@
+"""Subpackage containing all of pip's command line interface related code
+ """
+ 
+ # This file intentionally does not import submodules


### PR DESCRIPTION
## Summary by Sourcery

Chores:
- Marks the `Cli` directory as a Python subpackage.