### PR TITLE
Create Suporte_window.py

### DIFF
--- a/Setuptools/Suporte_window.py
+++ b/Setuptools/Suporte_window.py
@@ -1,0 +1,29 @@
+import platform
+import ctypes
+
+
+def windows_only(func):
+    if platform.system() != 'Windows':
+        return lambda *args, **kwargs: None
+    return func
+
+
+@windows_only
+def hide_file(path):
+    """
+    Set the hidden attribute on a file or directory.
+
+    From http://stackoverflow.com/questions/19622133/
+
+    `path` must be text.
+    """
+    __import__('ctypes.wintypes')
+    SetFileAttributes = ctypes.windll.kernel32.SetFileAttributesW
+    SetFileAttributes.argtypes = ctypes.wintypes.LPWSTR, ctypes.wintypes.DWORD
+    SetFileAttributes.restype = ctypes.wintypes.BOOL
+
+    FILE_ATTRIBUTE_HIDDEN = 0x02
+
+    ret = SetFileAttributes(path, FILE_ATTRIBUTE_HIDDEN)
+    if not ret:
+        raise ctypes.WinError()


### PR DESCRIPTION
suporte_window.py

## Summary by Sourcery

Add a utility function to hide files on Windows platforms

New Features:
- Implement a Windows-specific file hiding utility that sets the hidden attribute for a given file path

Enhancements:
- Create a decorator to restrict function execution to Windows platforms