### PR TITLE
Delete Ambiente/Env1 directory

### DIFF
--- a/Ambiente/Env1/pyvenv.cfg
+++ b/Ambiente/Env1/pyvenv.cfg
@@ -1,3 +1,0 @@
-home = C:\Program Files (x86)\Microsoft Visual Studio\Shared\Python39_64
-include-system-site-packages = false
-version = 3.9.13


### PR DESCRIPTION
## Summary by Sourcery

Chores:
- Delete the Ambiente/Env1 directory and its pyvenv.cfg file