### PR TITLE
Update style.css

### DIFF
--- a/style.css
+++ b/style.css
@@ -1,57 +1,18 @@
-/* style.css */
-*{
-  margin:0;
-  padding:0;
-  box-sizing:border-box;
-}
-
-body {
-  min-height:10px;
-  display:flex;
-  background-color: #c7d2fe;
-  font-size:16px;
-  align-items:center;
-  justify-content:center;
-}
-
-header {
+#btn-topo {
   position: fixed;
-  left:50%;
-  transform:translatex(-50%);
-  display:grid;
-  align-items:center;
-  grid-template-columns:1fr 600px;
-  gap:50px
-
-  & img{
-    width:250px
-  }
-}
-
-nav a {
-  color: black;
-  margin: 0 10px;
-  text-decoration: none;
-  display:flex;
-  padding:8px;
-  align-items:center;
-  border-radius:24px;
-}
-
-section {
-  width:100px;
-  height:32px;
-  padding: 2em;
-  background: #6046ff;
-  margin: 1em;
-  border-radius: 8px;
-  justify-content:center;
-  color:#ffffff;
-}
-
-footer {
-  text-align: center;
-  padding: 1em;
+  bottom: 30px;
+  right: 30px;
+  z-index: 1000;
+  padding: 12px;
+  border-radius: 50%;
   background: #222;
-  color: white;
+  color: #fff;
+  border: none;
+  cursor: pointer;
+  display: none;        /* oculto por padrão */
+  transition: opacity .3s;
+}
+
+#btn-topo.visible {
+  display: block;
 }


### PR DESCRIPTION
alter

## Summary by Sourcery

Remove legacy global and layout styles and introduce CSS for a scroll-to-top button

New Features:
- Add CSS rules for #btn-topo (scroll-to-top button) with fixed positioning, hidden default state, and visible class styling

Enhancements:
- Remove global reset and layout styles (body, header, nav, section, footer) to streamline the stylesheet